### PR TITLE
csr_matrix conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can then instantiate a classifier with the `interactive=True` flag set:
 clf = HierarchicalClassifier(
     base_estimator=svm.LinearSVC(),
     class_hierarchy=class_hierarchy,
-    interactive=True,
+    progress_wrapper=tqdm_notebook,
 )
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
         "scikit-learn>=0.19.0",
         "scipy>=0.19.1",
         "six>=1.10.0",
-        "tqdm>=4.15.0",
     ],
     setup_requires=[
         "nose>=1.3.7",

--- a/sklearn_hierarchical/array.py
+++ b/sklearn_hierarchical/array.py
@@ -2,7 +2,7 @@
 from itertools import chain
 
 import numpy as np
-from scipy.sparse import issparse, lil_matrix, csr_matrix
+from scipy.sparse import issparse, csr_matrix
 
 
 def flatten_list(lst):
@@ -85,7 +85,6 @@ def apply_rollup_Xy(X, y):
     indices = np.concatenate(indices)
     data = np.concatenate(data)
 
-    print(X, y)
     y_ = flatten_list(y)
     return csr_matrix((data, indices, indptr), shape=(n_rows, X.shape[1]), dtype=X.dtype), y_
 

--- a/sklearn_hierarchical/array.py
+++ b/sklearn_hierarchical/array.py
@@ -1,14 +1,12 @@
 """Helpers for workings with sequences and (numpy) arrays."""
+from itertools import chain
+
 import numpy as np
-from scipy.sparse import issparse, lil_matrix
+from scipy.sparse import issparse, lil_matrix, csr_matrix
 
 
 def flatten_list(lst):
-    return [
-        item
-        for sublist in lst
-        for item in sublist
-    ]
+    return list(chain(*lst))
 
 
 def apply_along_rows(func, X):
@@ -57,16 +55,39 @@ def apply_rollup_Xy(X, y):
         # No expansion needed
         return X, flatten_list(y)
 
-    X_ = lil_matrix((n_rows, X.shape[1]), dtype=X.dtype)
+    # Performance improvements require csr matrix
+    if not isinstance(X, csr_matrix):
+        X = csr_matrix(X)
+
+    indptr = np.zeros((n_rows+1), dtype=np.int32)
+    indices = []
+    data = []
+
+    indices_count = 0
     offset = 0
+
+    # Our goal is to expand the equal labelsets into their own row within X
+    # We do this by repeating each row exactly "labelset" times
     for i, labelset in enumerate(y):
         labelset_sz = len(labelset)
         for j in range(labelset_sz):
-            X_[offset+j] = X[i]
-        offset += labelset_sz
-    y_ = flatten_list(y)
+            indptr[offset+j] = indices_count
 
-    return X_.tocsr(), y_
+            indices.append(X.indices[X.indptr[i]:X.indptr[i+1]])
+            data.append(X.data[X.indptr[i]:X.indptr[i+1]])
+
+            indices_count += len(X.data[X.indptr[i]:X.indptr[i+1]])
+
+        offset += labelset_sz
+
+    indptr[-1] = indices_count
+
+    indices = np.concatenate(indices)
+    data = np.concatenate(data)
+
+    print(X, y)
+    y_ = flatten_list(y)
+    return csr_matrix((data, indices, indptr), shape=(n_rows, X.shape[1]), dtype=X.dtype), y_
 
 
 def nnz_rows_ix(X):

--- a/sklearn_hierarchical/classifier.py
+++ b/sklearn_hierarchical/classifier.py
@@ -4,7 +4,7 @@ Hierarchical classifier interface.
 """
 import numpy as np
 from networkx import DiGraph, is_tree
-from scipy.sparse import csr_matrix, lil_matrix
+from scipy.sparse import csr_matrix
 from sklearn.base import BaseEstimator, ClassifierMixin, MetaEstimatorMixin, clone
 from sklearn.dummy import DummyClassifier
 from sklearn.linear_model import LogisticRegression
@@ -109,8 +109,8 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
 
     progress_wrapper : progress generator or None
         If value is set, will attempt to use the given generator to display progress updates. This added functionality
-        is especially useful within interactive environments (e.g in a testing harness or a Jupyter notebook). Setting this
-        value will also enable verbose logging. Common values in tqdm are `tqdm_notebook` or `tqdm`
+        is especially useful within interactive environments (e.g in a testing harness or a Jupyter notebook). Setting
+        this value will also enable verbose logging. Common values in tqdm are `tqdm_notebook` or `tqdm`
 
     Attributes
     ----------

--- a/sklearn_hierarchical/graph.py
+++ b/sklearn_hierarchical/graph.py
@@ -24,9 +24,13 @@ def rollup_nodes(graph, source, targets):
     given source node in given graph.
 
     """
+    result_cache = {}
     resultset = []
     for node_id in targets:
-        all_paths = all_simple_paths(G=graph, source=source, target=node_id)
+        if node_id not in result_cache:
+            result_cache[node_id] = list(all_simple_paths(G=graph, source=source, target=node_id))
+
+        all_paths = result_cache[node_id]
         resultset.append([
             path[1]
             for path in all_paths

--- a/sklearn_hierarchical/tests/fixtures.py
+++ b/sklearn_hierarchical/tests/fixtures.py
@@ -39,7 +39,7 @@ def make_class_hierarchy(n, n_intermediate=None, n_leaf=None):
         if n_leaf is None:
             n_leaf = n - 1
 
-        G = DiGraph(data=product((ROOT,), range(n_leaf)))
+        G = DiGraph(product((ROOT,), range(n_leaf)))
 
     return to_dict_of_lists(G)
 


### PR DESCRIPTION
Primary bottleneck of training is splicing matrices.  Converting the primary lil_matrix operations into csr_matrix constructors achieves a ~15x speedup when working with large datasets.