### PR TITLE
Support usage of intermediate nodes as labels in training data

### DIFF
--- a/sklearn_hierarchical_classification/classifier.py
+++ b/sklearn_hierarchical_classification/classifier.py
@@ -397,10 +397,8 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
             targets=[y[idx] for idx in nnz_rows],
         )
 
-        self.logger.debug("_train_local_classifier() - y: %s, nnz_rows: %s, y_rolled_up: %s", y, nnz_rows, y_rolled_up)
         if self.is_tree_:
             y_ = flatten_list(y_rolled_up)
-            self.logger.debug("_train_local_classifier() - graph is a tree, y_: %s", y_)
         else:
             # Class hierarchy graph is a DAG
             X_, y_ = apply_rollup_Xy(X_, y_rolled_up)

--- a/sklearn_hierarchical_classification/tests/fixtures.py
+++ b/sklearn_hierarchical_classification/tests/fixtures.py
@@ -29,6 +29,7 @@ def make_class_hierarchy(n, n_intermediate=None, n_leaf=None):
     Returns
     -------
     G : dict of lists adjacency matrix format representing the class hierarchy
+
     """
     if n_leaf is None and n_intermediate is None:
         # No specific structure specified, use a general purpose graph generator
@@ -72,6 +73,10 @@ def make_classifier_and_data(
     class_hierarchy=None,
     **classifier_kwargs
 ):
+    """Create a classifier as well as a synthetic dataset, with optional support for
+    user-specific class hierarchy.
+
+    """
     X, y = make_blobs(
         n_samples=n_samples,
         n_features=n_features,
@@ -89,3 +94,29 @@ def make_classifier_and_data(
     )
 
     return clf, (X, y)
+
+
+def make_clothing_graph(root=ROOT):
+    """Create a mock hierarchy of clothing items."""
+    G = DiGraph()
+    G.add_edge(root, "Mens")
+    G.add_edge("Mens", "Shirts")
+    G.add_edge("Mens", "Bottoms")
+    G.add_edge("Mens", "Jackets")
+    G.add_edge("Mens", "Swim")
+
+    return G
+
+
+def make_clothing_graph_and_data(root=ROOT):
+    """Create a graph for hierarchical classification
+    of clothing items, along with mock training data.
+
+    """
+    G = make_clothing_graph(root)
+
+    labels = list(G.nodes() - [root])
+    y = np.random.choice(labels, size=50)
+    X = np.random.normal(size=(len(y), 10))
+
+    return G, (X, y)

--- a/sklearn_hierarchical_classification/tests/test_classifier.py
+++ b/sklearn_hierarchical_classification/tests/test_classifier.py
@@ -16,6 +16,7 @@ from numpy import where
 from sklearn import svm
 from sklearn.metrics import accuracy_score
 from sklearn.model_selection import train_test_split
+from sklearn.linear_model import LogisticRegression
 from sklearn.naive_bayes import MultinomialNB
 from sklearn.neighbors import KNeighborsClassifier
 from sklearn.utils.estimator_checks import check_estimator
@@ -25,6 +26,7 @@ from sklearn_hierarchical_classification.constants import CLASSIFIER, DEFAULT, R
 from sklearn_hierarchical_classification.tests.fixtures import (
     make_classifier,
     make_classifier_and_data,
+    make_clothing_graph_and_data,
     make_digits_dataset,
 )
 from sklearn_hierarchical_classification.tests.matchers import matches_graph
@@ -156,6 +158,37 @@ def test_nontrivial_hierarchy_leaf_classification():
     assert_that(accuracy, is_(close_to(1., delta=0.02)))
 
 
+def test_intermediate_node_training_data():
+    r"""Test that a training set which includes intermediate (non-leaf) nodes
+    as labels, as well as leaf nodes, constructs a correct classifier hierarchy
+
+    """
+    G, (X, y) = make_clothing_graph_and_data(root=ROOT)
+
+    # Add a new node rendering "Bottoms" an intermediate node with training data
+    G.add_edge("Bottoms", "Pants")
+
+    assert_that(any(yi == "Pants" for yi in y), is_(False))
+    assert_that(any(yi == "Bottoms" for yi in y), is_(True))
+
+    base_estimator = LogisticRegression(
+        solver="lbfgs",
+        max_iter=1_000,
+        multi_class="multinomial",
+    )
+
+    clf = HierarchicalClassifier(
+        base_estimator,
+        class_hierarchy=G,
+        algorithm="lcpn",
+        root=ROOT,
+    )
+    clf.fit(X, y)
+
+    # Ensure non-terminal node with training data is included in its' parent classifier classes
+    assert_that(clf.graph_.nodes()["Mens"]["classifier"].classes_, has_item("Bottoms"))
+
+
 def test_nmlnp_strategy_with_float_stopping_criteria():
     # since NMLNP results in a mix of intermediate and leaf nodes,
     # make sure they are all of same dtype (str)
@@ -228,8 +261,8 @@ def test_nmlnp_strategy_on_tree_with_dummy_classifier():
 
 
 def test_nmlnp_strategy_on_dag_with_dummy_classifier():
-    """Test classification works on a "deep" DAG when one of the nodes has out-degree 1 resulting in
-    creation of a "dummy" classifier at that node to triially predict its child.
+    """Test classification works on a "deep" DAG when one of the nodes has out-degree 1,
+    resulting in creation of a "dummy" classifier at that node to trivially predict its child.
 
     This test case actually tests a few more subtle edge cases:
 


### PR DESCRIPTION
This PR addresses an issue that was raised in #31 - namely, we were not correctly building the per-node training data set (X, y) in a case where some of the training labels given are pointing to intermediate (non-leaf) nodes.

In addition, we add unit-test coverage for these cases to avoid regressions going forward, and make a couple other small updates to remove some warnings that are emitted in unit-tests due to scikit-learn.