### PR TITLE
Support passing in MultiLabelBinarizer and Raw Training Data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ pip-log.txt
 pip-delete-this-directory.txt
 
 # Unit test / coverage reports
+coverage/
 htmlcov/
 .tox/
 .coverage
@@ -96,3 +97,6 @@ target/
 
 # gh-pages
 public
+
+# pyenv
+.python-version

--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ To install, simply install this package via pip into your desired virtualenv, e.
 See [examples/](./examples/) for usage examples.
 
 
+## Testing
+
+To run the included unit-tests, install the test dependencies and then invoke using `nose`:
+
+    pip install -e '.[test]'
+    pip install nose
+    nosetests
+
+
 ### Jupyter notebooks
 
 Support for interactive development is built in to the `HierarchicalClassifier` class. This will enable progress bars (using the excellent [tqdm](https://pypi.python.org/pypi/tqdm) library) in various places during training and may otherwise enable more visibility into the classifier which is useful during interactive use. To enable this make sure widget extensions are enabled by running:
@@ -47,12 +56,6 @@ Auto-generated documentation is provided via sphinx. To build / view:
 
 Documentation is published to GitHub pages from the `gh-pages` branch.
 If you are a contributor and need to update documentation, a good starting point for getting setup is [this tutorial](https://gohugo.io/hosting-and-deployment/hosting-on-github/#deployment-of-project-pages-from-docs-folder-on-master-branch).
-
-## Testing
-
-Install hamcrest and pytest:
-pip install PyHamcrest pytest
-
 
 
 ## Further Reading

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Auto-generated documentation is provided via sphinx. To build / view:
 Documentation is published to GitHub pages from the `gh-pages` branch.
 If you are a contributor and need to update documentation, a good starting point for getting setup is [this tutorial](https://gohugo.io/hosting-and-deployment/hosting-on-github/#deployment-of-project-pages-from-docs-folder-on-master-branch).
 
+## Testing
+
+Install hamcrest and pytest:
+pip install PyHamcrest pytest
+
+
 
 ## Further Reading
 

--- a/sklearn_hierarchical_classification/array.py
+++ b/sklearn_hierarchical_classification/array.py
@@ -142,3 +142,38 @@ def nnz_rows_ix(X):
 def nnz_columns_count(X):
     """Return count of columns which have at least one non-zero value."""
     return len(np.count_nonzero(X, axis=0))
+
+def apply_rollup_Xy_raw(X, y):
+    """
+    Parameters
+    ----------
+    X : List
+
+    y : list-of-lists - [n_samples]
+        For each sample, y maintains list of labels this sample should be used for in training.
+
+    Returns
+    -------
+    X_, y_
+        Transformed by 'flattening' out y parameter and duplicating corresponding rows in X
+
+    """
+    # Compute number of rows we will have after transformation
+    n_rows = sum(len(labelset) for labelset in y)
+
+    if n_rows == X.shape[0]:
+        # No expansion needed
+        return X, flatten_list(y)
+
+
+
+    # Our goal is to expand the equal labelsets into their own row within X
+    # We do this by repeating each row exactly "labelset" times
+    X_rows=[]
+    for i, labelset in enumerate(y):
+        labelset_sz = len(labelset)
+        for j in range(labelset_sz):
+            X_rows.append(X[j])
+
+    y_ = flatten_list(y)
+    return X_rows, y_

--- a/sklearn_hierarchical_classification/array.py
+++ b/sklearn_hierarchical_classification/array.py
@@ -55,8 +55,8 @@ def apply_rollup_Xy(X, y):
         # No expansion needed
         return X, flatten_list(y)
 
-    # Performance improvements require csr matrix
     if not isinstance(X, csr_matrix):
+        # Performance improvements require csr matrix
         X = csr_matrix(X)
 
     indptr = np.zeros((n_rows+1), dtype=np.int32)
@@ -87,6 +87,40 @@ def apply_rollup_Xy(X, y):
 
     y_ = flatten_list(y)
     return csr_matrix((data, indices, indptr), shape=(n_rows, X.shape[1]), dtype=X.dtype), y_
+
+
+def apply_rollup_Xy_raw(X, y):
+    """
+    Parameters
+    ----------
+    X : List
+
+    y : list-of-lists - [n_samples]
+        For each sample, y maintains list of labels this sample should be used for in training.
+
+    Returns
+    -------
+    X_, y_
+        Transformed by 'flattening' out y parameter and duplicating corresponding rows in X
+
+    """
+    # Compute number of rows we will have after transformation
+    n_rows = sum(len(labelset) for labelset in y)
+
+    if n_rows == X.shape[0]:
+        # No expansion needed
+        return X, flatten_list(y)
+
+    # Our goal is to expand the equal labelsets into their own row within X
+    # We do this by repeating each row exactly "labelset" times
+    X_rows = []
+    for i, labelset in enumerate(y):
+        labelset_sz = len(labelset)
+        for j in range(labelset_sz):
+            X_rows.append(X[j])
+
+    y_ = flatten_list(y)
+    return X_rows, y_
 
 
 def extract_rows_csr(matrix, rows):
@@ -142,38 +176,3 @@ def nnz_rows_ix(X):
 def nnz_columns_count(X):
     """Return count of columns which have at least one non-zero value."""
     return len(np.count_nonzero(X, axis=0))
-
-def apply_rollup_Xy_raw(X, y):
-    """
-    Parameters
-    ----------
-    X : List
-
-    y : list-of-lists - [n_samples]
-        For each sample, y maintains list of labels this sample should be used for in training.
-
-    Returns
-    -------
-    X_, y_
-        Transformed by 'flattening' out y parameter and duplicating corresponding rows in X
-
-    """
-    # Compute number of rows we will have after transformation
-    n_rows = sum(len(labelset) for labelset in y)
-
-    if n_rows == X.shape[0]:
-        # No expansion needed
-        return X, flatten_list(y)
-
-
-
-    # Our goal is to expand the equal labelsets into their own row within X
-    # We do this by repeating each row exactly "labelset" times
-    X_rows=[]
-    for i, labelset in enumerate(y):
-        labelset_sz = len(labelset)
-        for j in range(labelset_sz):
-            X_rows.append(X[j])
-
-    y_ = flatten_list(y)
-    return X_rows, y_

--- a/sklearn_hierarchical_classification/classifier.py
+++ b/sklearn_hierarchical_classification/classifier.py
@@ -24,6 +24,7 @@ from sklearn.utils.validation import (
 from sklearn_hierarchical_classification.array import (
     apply_along_rows,
     apply_rollup_Xy,
+    apply_rollup_Xy_raw,
     extract_rows_csr,
     flatten_list,
     nnz_rows_ix,
@@ -53,16 +54,16 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
 
     - Multi-label classification - Do we support classifying into more than a single target class/label
     - Mandatory / Non-mandatory leaf node prediction - Do we require that classification always results with
-      classes corresponding to leaf nodes, or can intermediate nodes also be treated as valid output predictions.
+        classes corresponding to leaf nodes, or can intermediate nodes also be treated as valid output predictions.
     - Local classifiers - the local (or "base") classifiers can theoretically be chosen to be of any kind, but we
-      distinguish between three main modes of local classification:
+        distinguish between three main modes of local classification:
             * "One classifier per parent node" - where each non-leaf node can be fitted with a multi-class
-              classifier to predict which one of its child nodes is relevant for given example.
+                classifier to predict which one of its child nodes is relevant for given example.
             * "One classifier per node" - where each node is fitted with a binary "membership" classifier which
-              returns a binary (or a probability) score indicating the fitness for that node and the current
-              example.
+                returns a binary (or a probability) score indicating the fitness for that node and the current
+                example.
             * Global / "big bang" classifiers - where a single classifier predicts the full path in the hierarchy
-              for a given example.
+                for a given example.
 
     The nomenclature used here is based on the framework outlined in [1].
 
@@ -77,7 +78,7 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
         when building the classifier tree, the dictionary will be consulted and if a key is found matching
         a particular node, the base classifier pointed to in the dict will be used. Since this is most often
         useful for specifying classifiers on only a handlful of objects, a special 'DEFAULT' key can be used to
-        set the base classifier to use as a catch all.
+        set the base classifier to use as a 'catch all'.
         If not provided, a base estimator will be chosen by the framework using various meta-learning
         heuristics (WIP).
 
@@ -211,16 +212,17 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
             for node in self.graph_.nodes()
             if node != self.root
         )
-        self.logger.debug("fit() - self.classes_ = %s", self.classes_)
 
         # Recursively build training feature sets for each node in graph
-        with self._progress(total=self.n_classes_ + 1, desc="Building features") as progress:
-            self._recursive_build_features(X, y, node_id=self.root, progress=progress)
+        if not self.preprocessing:
+            with self._progress(total=self.n_classes_ + 1, desc="Building features") as progress:
+                self._recursive_build_features(X, y, node_id=self.root, progress=progress)
 
         # Recursively train base classifiers
         with self._progress(total=self.n_classes_ + 1, desc="Training base classifiers") as progress:
             self._recursive_train_local_classifiers(X, y, node_id=self.root, progress=progress)
 
+        self.avglabs = np.mean(y.sum(1))
         return self
 
     def predict(self, X):
@@ -344,7 +346,7 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
                     progress=progress,
                 )
 
-        # Build and store meta-features for node
+        # Build and store metafeatures for node
         self.graph_.nodes[node_id][METAFEATURES] = self._build_metafeatures(
             X=self.graph_.nodes[node_id]["X"],
             y=y,
@@ -515,20 +517,23 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
         else:
             clf = self._base_estimator_for(node_id)
 
-<<<<<<< HEAD
-        if len(X_) > 0:
-            clf.fit(X=X_, y=y_)
-        self.graph_.nodes[node_id][CLASSIFIER] = clf
-=======
-
         if self.preprocessing:
-            if len(X_)>0:
+            if len(X_) > 0:
                 clf.fit(X=X_, y=y_)
+                self.logger.debug(
+                    "_train_local_classifier() - training node %s ",  # noqa:E501
+                    node_id,
+                )
+                self.graph_.node[node_id][CLASSIFIER] = clf
+            else:
+                self.logger.debug(
+                    "_train_local_classifier() - could not train  node %s ",  # noqa:E501
+                    node_id,
+                )
+
         else:
             clf.fit(X=X_, y=y_)
-
-        self.graph_.node[node_id][CLASSIFIER] = clf
->>>>>>> d115845... fixed error so classify_digits.py works now again
+            self.graph_.nodes[node_id][CLASSIFIER] = clf
 
     def _recursive_predict(self, x, root):
         if CLASSIFIER not in self.graph_.nodes[root]:
@@ -540,12 +545,13 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
 
         while clf:
             if hasattr(clf, "decision_function"):
-                if self.preprocessing or self.mlb:
+                if self.preprocessing:
                     probs = clf.decision_function([x])
                     argmax = np.argmax(probs)
                     score = probs[0, argmax]
+
                 else:
-                    probs = clf.predict_proba(x)[0]
+                    probs = clf.decision_function(x)
                     argmax = np.argmax(probs)
                     score = probs[argmax]
 

--- a/sklearn_hierarchical_classification/classifier.py
+++ b/sklearn_hierarchical_classification/classifier.py
@@ -160,7 +160,7 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
     def __init__(self, base_estimator=None, class_hierarchy=None, prediction_depth="mlnp",
                  algorithm="lcpn", training_strategy=None, stopping_criteria=None,
                  root=ROOT, progress_wrapper=None, preprocessing=False, mlb=None,
-                 use_decision_function=False):
+                 use_decision_function=False, threshold=0.):
         self.base_estimator = base_estimator
         self.class_hierarchy = class_hierarchy
         self.prediction_depth = prediction_depth
@@ -171,7 +171,7 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
         self.progress_wrapper = progress_wrapper
         self.preprocessing = preprocessing
         self.mlb = mlb
-        self.threshold = 0
+        self.threshold = threshold
         self.use_decision_function = use_decision_function
 
     def fit(self, X, y=None, sample_weight=None):
@@ -539,7 +539,7 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
                     "_train_local_classifier() - training node %s ",  # noqa:E501
                     node_id,
                 )
-                self.graph_.node[node_id][CLASSIFIER] = clf
+                self.graph_.nodes[node_id][CLASSIFIER] = clf
             else:
                 self.logger.debug(
                     "_train_local_classifier() - could not train  node %s ",  # noqa:E501

--- a/sklearn_hierarchical_classification/classifier.py
+++ b/sklearn_hierarchical_classification/classifier.py
@@ -515,9 +515,20 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
         else:
             clf = self._base_estimator_for(node_id)
 
+<<<<<<< HEAD
         if len(X_) > 0:
             clf.fit(X=X_, y=y_)
         self.graph_.nodes[node_id][CLASSIFIER] = clf
+=======
+
+        if self.preprocessing:
+            if len(X_)>0:
+                clf.fit(X=X_, y=y_)
+        else:
+            clf.fit(X=X_, y=y_)
+
+        self.graph_.node[node_id][CLASSIFIER] = clf
+>>>>>>> d115845... fixed error so classify_digits.py works now again
 
     def _recursive_predict(self, x, root):
         if CLASSIFIER not in self.graph_.nodes[root]:
@@ -529,9 +540,15 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
 
         while clf:
             if hasattr(clf, "decision_function"):
-                probs = clf.decision_function([x])
-                argmax = np.argmax(probs)
-                score = probs[0, argmax]
+                if self.preprocessing or self.mlb:
+                    probs = clf.decision_function([x])
+                    argmax = np.argmax(probs)
+                    score = probs[0, argmax]
+                else:
+                    probs = clf.predict_proba(x)[0]
+                    argmax = np.argmax(probs)
+                    score = probs[argmax]
+
             else:
                 probs = clf.predict_proba(x)[0]
                 argmax = np.argmax(probs)

--- a/sklearn_hierarchical_classification/classifier.py
+++ b/sklearn_hierarchical_classification/classifier.py
@@ -134,6 +134,15 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
         is especially useful within interactive environments (e.g in a testing harness or a Jupyter notebook). Setting
         this value will also enable verbose logging. Common values in tqdm are `tqdm_notebook` or `tqdm`
 
+    preprocessing : bool
+        Determines if the classifier has its own preprocessing (for text processing for example).
+
+    mlb : MultiLabelBinarizer
+        For Multilabel the used MultiLabelBinarizer for creating the y variable (important for giving classes back)
+
+    use_decision_function : bool
+        Tests fail when using decision_function, since they expect predict_proba to sum to 1. Use True here allows to receive different values which can be more interesting to compare between rows/samples.
+    
     Attributes
     ----------
     classes_ : array, shape = [`n_classes`]

--- a/sklearn_hierarchical_classification/classifier.py
+++ b/sklearn_hierarchical_classification/classifier.py
@@ -48,7 +48,7 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
     Hierarchical classification deals with the scenario where our target classes have
     inherent structure that can be represented as a tree or a directed acyclic graph (DAG),
     with nodes representing the target classes themselves, and edges representing their inter-relatedness,
-    e.g 'IS A' semantics.
+    e.g "IS A" semantics.
 
     Within this general framework, several distinctions can be made based on a few key modelling decisions:
 
@@ -70,15 +70,15 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
     Parameters
     ----------
     base_estimator : classifier object, function, dict, or None
-        A scikit-learn compatible classifier object implementing 'fit' and 'predict_proba' to be used as the
+        A scikit-learn compatible classifier object implementing "fit" and "predict_proba" to be used as the
         base classifier.
         If a callable function is given, it will be called to evaluate which classifier to instantiate for
         current node. The function will be called with the current node and the graph instance.
         Alternatively, a dictionary mapping classes to classifier objects can be given. In this case,
         when building the classifier tree, the dictionary will be consulted and if a key is found matching
         a particular node, the base classifier pointed to in the dict will be used. Since this is most often
-        useful for specifying classifiers on only a handlful of objects, a special 'DEFAULT' key can be used to
-        set the base classifier to use as a 'catch all'.
+        useful for specifying classifiers on only a handlful of objects, a special "DEFAULT" key can be used to
+        set the base classifier to use as a "catch all".
         If not provided, a base estimator will be chosen by the framework using various meta-learning
         heuristics (WIP).
 
@@ -106,11 +106,11 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
 
     training_strategy: "exclusive", "less_exclusive", "inclusive", "less_inclusive",
                        "siblings", "exclusive_siblings", or None.
-        This parameter is used when the 'algorithm' parameter is to set to "lcn", and dictates how training data
+        This parameter is used when the "algorithm" parameter is to set to "lcn", and dictates how training data
         is constructed for training the binary classifier at each node.
 
     stopping_criteria: function, float, or None.
-        This parameter is used when the 'prediction_depth' parameter is set to "nmlnp", and is used to evaluate
+        This parameter is used when the "prediction_depth" parameter is set to "nmlnp", and is used to evaluate
         at a given node whether classification should terminate or continue further down the hierarchy.
 
         When set to a float, the prediction will stop if the reported confidence at current classifier is below
@@ -126,7 +126,7 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
         The unique identifier for the qualified root node in the class hierarchy. The hierarchical classifier
         assumes that the given class hierarchy graph is a rooted DAG, e.g has a single designated root node
         of in-degree 0. This node is associated with a special identifier which defaults to a framework provided one,
-        but can be overridden by user in some cases, e.g if the original taxonomy is already rooted and there's no need
+        but can be overridden by user in some cases, e.g if the original taxonomy is already rooted and there"s no need
         for injecting an artifical root node.
 
     progress_wrapper : progress generator or None
@@ -195,18 +195,22 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
 
         """
         if self.preprocessing:
+            # In pre-processing mode, only validate targets (y) format and
+            # that targets and training data (X) are of same cardinality, since
+            # X will in general not be a 2D feature matrix, but rather the raw training examples,
+            # e.g. text snippets or images.
+            X, y = check_X_y(X, y, accept_sparse="csr")
             y = check_array(
                 y,
-                'csr',
+                accept_sparse="csr",
                 force_all_finite=True,
                 ensure_2d=False,
                 dtype=None,
             )
-
             if len(X) != y.shape[0]:
                 raise ValueError("bad input shape: len(X) != y.shape[0]")
         else:
-            X, y = check_X_y(X, y, accept_sparse='csr')
+            X, y = check_X_y(X, y, accept_sparse="csr")
 
         check_classification_targets(y)
         if sample_weight is not None:
@@ -225,18 +229,14 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
             if node != self.root
         )
 
-        # Recursively build training feature sets for each node in graph
         if not self.preprocessing:
+            # When not in pre-processing mode, recursively build training feature sets for each node in graph
             with self._progress(total=self.n_classes_ + 1, desc="Building features") as progress:
                 self._recursive_build_features(X, y, node_id=self.root, progress=progress)
 
         # Recursively train base classifiers
         with self._progress(total=self.n_classes_ + 1, desc="Training base classifiers") as progress:
             self._recursive_train_local_classifiers(X, y, node_id=self.root, progress=progress)
-
-        # TODO: future feature, using the label cardinality to calculate threshold
-        if len(y.shape) == 2:
-            self.avglabs = np.mean(y.sum(1))
 
         return self
 
@@ -384,7 +384,7 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
 
     def _build_features(self, X, y, indices):
         if self.preprocessing:
-            X_ = [X[tk] for tk in indices]
+            X_ = [X[ix] for ix in indices]
         else:
             X_ = extract_rows_csr(X, indices)
 
@@ -419,8 +419,8 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
         -------
         metafeatures : dict
             Python dictionary of meta-features. The following meta-features are computed by default:
-            * 'n_samples' - Number of samples used to train classifier at given node.
-            * 'n_targets' - Number of targets (classes) to classify into at given node.
+            * "n_samples" - Number of samples used to train classifier at given node.
+            * "n_targets" - Number of targets (classes) to classify into at given node.
 
         """
         if self.preprocessing:
@@ -512,7 +512,7 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
 
         if not self.preprocessing and X_.shape[0] == 0:
             # No training data could be materialized for current node
-            # TODO: support a 'strict' mode flag to explicitly enable/disable fallback logic here?
+            # TODO: support a "strict" mode flag to explicitly enable/disable fallback logic here?
             self.logger.warning(
                 "_train_local_classifier() - not enough training data available to train, classification in branch will terminate at node %s",  # noqa:E501
                 node_id,
@@ -520,7 +520,7 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
             return
         elif num_targets == 1:
             # Training data could be materialized for only a single target at current node
-            # TODO: support a 'strict' mode flag to explicitly enable/disable fallback logic here?
+            # TODO: support a "strict" mode flag to explicitly enable/disable fallback logic here?
             constant = y_[0]
             self.logger.debug(
                 "_train_local_classifier() - only a single target (child node) available to train classifier for node %s, Will trivially predict %s",  # noqa:E501
@@ -588,7 +588,7 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
                         class_idx = self.classes_.index(class_)
                     except ValueError:
                         # This may happen if the classes_ enumeration we construct during fit()
-                        # has a mismatch with the individual node classifiers' classes_.
+                        # has a mismatch with the individual node classifiers" classes_.
                         self.logger.error(
                             "Could not find index in self.classes_ for class_ = '%s' (type: %s). path: %s",
                             class_,
@@ -636,8 +636,8 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
         """
         Evaluate whether classification should terminate at given step.
 
-        This depends on whether early-termination, as dictated by the the 'prediction_depth'
-          and 'stopping_criteria' parameters, is triggered.
+        This depends on whether early-termination, as dictated by the the "prediction_depth"
+          and "stopping_criteria" parameters, is triggered.
 
         """
         if self.prediction_depth != "nmlnp":

--- a/sklearn_hierarchical_classification/classifier.py
+++ b/sklearn_hierarchical_classification/classifier.py
@@ -275,7 +275,6 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
         check_is_fitted(self, "graph_")
 
         def _classify(x):
-            # TODO support multi-label / paths?
             path, _ = self._recursive_predict(x, root=self.root)
             if self.mlb:
                 return path

--- a/sklearn_hierarchical_classification/classifier.py
+++ b/sklearn_hierarchical_classification/classifier.py
@@ -141,8 +141,9 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
         For Multilabel the used MultiLabelBinarizer for creating the y variable (important for giving classes back)
 
     use_decision_function : bool
-        Tests fail when using decision_function, since they expect predict_proba to sum to 1. Use True here allows to receive different values which can be more interesting to compare between rows/samples.
-    
+        Tests fail when using decision_function, since they expect predict_proba to sum to 1.
+        Use True here allows to receive different values which can be more interesting to compare between rows/samples.
+
     Attributes
     ----------
     classes_ : array, shape = [`n_classes`]
@@ -549,9 +550,10 @@ class HierarchicalClassifier(BaseEstimator, ClassifierMixin, MetaEstimatorMixin)
             clf.fit(X=X_, y=y_)
             self.graph_.nodes[node_id][CLASSIFIER] = clf
 
-    def _recursive_predict(self, x, root):
+    def _recursive_predict(self, x, root):  # noqa:C901 TODO: refactor
         if CLASSIFIER not in self.graph_.nodes[root]:
             return None, None
+
         clf = self.graph_.nodes[root][CLASSIFIER]
         path = [root]
         path_proba = []

--- a/sklearn_hierarchical_classification/constants.py
+++ b/sklearn_hierarchical_classification/constants.py
@@ -6,7 +6,6 @@ Constants.
 # Special id reserved for an artificial 'root node' that may be added to class hierarchy
 # when using a 'one classifier per parent node' strategy.
 ROOT = "<ROOT>"
-#ROOT = -1
 
 # Dictionary keys used in various places by classifier
 CLASSIFIER = "classifier"

--- a/sklearn_hierarchical_classification/constants.py
+++ b/sklearn_hierarchical_classification/constants.py
@@ -5,8 +5,8 @@ Constants.
 
 # Special id reserved for an artificial 'root node' that may be added to class hierarchy
 # when using a 'one classifier per parent node' strategy.
-#ROOT = "<ROOT>"
-ROOT = -1
+ROOT = "<ROOT>"
+#ROOT = -1
 
 # Dictionary keys used in various places by classifier
 CLASSIFIER = "classifier"

--- a/sklearn_hierarchical_classification/constants.py
+++ b/sklearn_hierarchical_classification/constants.py
@@ -5,7 +5,8 @@ Constants.
 
 # Special id reserved for an artificial 'root node' that may be added to class hierarchy
 # when using a 'one classifier per parent node' strategy.
-ROOT = "<ROOT>"
+#ROOT = "<ROOT>"
+ROOT = -1
 
 # Dictionary keys used in various places by classifier
 CLASSIFIER = "classifier"

--- a/sklearn_hierarchical_classification/constants.py
+++ b/sklearn_hierarchical_classification/constants.py
@@ -14,6 +14,7 @@ METAFEATURES = "metafeatures"
 
 # Enumeration of valid configuration types
 VALID_ALGORITHM = ("lcn", "lcpn")
+VALID_FEATURE_EXTRACTION = ("preprocessed", "raw")
 VALID_PREDICTION_DEPTH = ("mlnp", "nmlnp")
 VALID_TRAINING_STRATEGY = ("exclusive", "less_exclusive", "inclusive", "less_inclusive",
                            "siblings", "exclusive_siblings")

--- a/sklearn_hierarchical_classification/graph.py
+++ b/sklearn_hierarchical_classification/graph.py
@@ -4,8 +4,8 @@ Graph processing helpers.
 """
 from collections import defaultdict
 
-import numpy as np
 from networkx import all_simple_paths
+from numpy import ndarray
 
 
 def make_flat_hierarchy(targets, root):
@@ -24,7 +24,7 @@ def rollup_nodes(graph, source, targets, mlb=None):
     result_cache = {}
     resultset = []
     for node_id in targets:
-        if type(node_id) is np.ndarray:
+        if type(node_id) == ndarray:
             res_row = []
             for lab in node_id.nonzero()[0]:
                 if lab not in result_cache:

--- a/sklearn_hierarchical_classification/graph.py
+++ b/sklearn_hierarchical_classification/graph.py
@@ -6,6 +6,8 @@ from collections import defaultdict
 
 from networkx import all_simple_paths
 
+import numpy as np
+
 
 def make_flat_hierarchy(targets, root):
     """Create a trivial (flat) hiearchy, linking all given targets to given root node."""
@@ -15,7 +17,7 @@ def make_flat_hierarchy(targets, root):
     return adjacency
 
 
-def rollup_nodes(graph, source, targets):
+def rollup_nodes(graph, source, targets, mlb=None):
     """Perform a "roll-up" of given target nodes up to the nodes immediately below
     given source node in given graph.
 
@@ -23,14 +25,28 @@ def rollup_nodes(graph, source, targets):
     result_cache = {}
     resultset = []
     for node_id in targets:
-        if node_id not in result_cache:
-            result_cache[node_id] = list(all_simple_paths(G=graph, source=source, target=node_id))
+        if type(node_id) is np.ndarray:
+            res_row = []
+            for lab in node_id.nonzero()[0]:
+                if lab not in result_cache:
+                    result_cache[lab] = list(all_simple_paths(G=graph, source=source, target=mlb.classes_[lab]))
 
-        all_paths = result_cache[node_id]
-        resultset.append([
-            path[1]
-            for path in all_paths
-        ])
+                all_paths = result_cache[lab]
+
+                res_row.extend([
+                    path[1]
+                    for path in all_paths
+                ])
+            resultset.append(res_row)
+        else:
+            if node_id not in result_cache:
+                result_cache[node_id] = list(all_simple_paths(G=graph, source=source, target=node_id))
+
+            all_paths = result_cache[node_id]
+            resultset.append([
+                path[1]
+                for path in all_paths
+            ])
 
     assert len(resultset) == len(targets)
 

--- a/sklearn_hierarchical_classification/graph.py
+++ b/sklearn_hierarchical_classification/graph.py
@@ -24,23 +24,22 @@ def rollup_nodes(graph, source, targets, mlb=None):
     result_cache = {}
     resultset = []
     for node_id in targets:
-        if type(node_id) == ndarray:
-            res_row = []
-            for lab in node_id.nonzero()[0]:
-                if lab not in result_cache:
-                    result_cache[lab] = list(all_simple_paths(G=graph, source=source, target=mlb.classes_[lab]))
-
-                all_paths = result_cache[lab]
-
-                res_row.extend([
+        if mlb and type(node_id) == ndarray:
+            # multi-label binarizer was passed and node_id is an array, perform a roll-up
+            # for multi-label targets.
+            result_row = []
+            for label in node_id.nonzero()[0]:
+                if label not in result_cache:
+                    result_cache[label] = list(all_simple_paths(G=graph, source=source, target=mlb.classes_[label]))
+                all_paths = result_cache[label]
+                result_row.extend([
                     path[1]
                     for path in all_paths
                 ])
-            resultset.append(res_row)
+            resultset.append(result_row)
         else:
             if node_id not in result_cache:
                 result_cache[node_id] = list(all_simple_paths(G=graph, source=source, target=node_id))
-
             all_paths = result_cache[node_id]
             resultset.append([
                 path[1]

--- a/sklearn_hierarchical_classification/graph.py
+++ b/sklearn_hierarchical_classification/graph.py
@@ -4,9 +4,8 @@ Graph processing helpers.
 """
 from collections import defaultdict
 
-from networkx import all_simple_paths
-
 import numpy as np
+from networkx import all_simple_paths
 
 
 def make_flat_hierarchy(targets, root):

--- a/sklearn_hierarchical_classification/tests/fixtures.py
+++ b/sklearn_hierarchical_classification/tests/fixtures.py
@@ -141,7 +141,7 @@ def make_classifier_and_data(
     return clf, (X, y)
 
 
-def make_classifier_and_data_own_preprocessing():
+def make_mlb_classifier_and_data_with_preprocessing():
     """Create data set and classifier for testing a multi-label
     classification scenario with a preprocessing pipeline.
 
@@ -164,8 +164,8 @@ def make_classifier_and_data_own_preprocessing():
         sublinear_tf=True,
         max_features=70000
     )
-    bclf = OneVsRestClassifier(LinearSVC())
-    base_estimator = make_pipeline(vectorizer, bclf)
+    binary_clf = OneVsRestClassifier(LinearSVC())
+    base_estimator = make_pipeline(vectorizer, binary_clf)
 
     labels = [
         [names[target]] + [names[target].split(".")[0]]
@@ -177,7 +177,7 @@ def make_classifier_and_data_own_preprocessing():
     clf = make_classifier(
         base_estimator=base_estimator,
         class_hierarchy=class_hierarchy,
-        preprocessing=True,
+        feature_extraction="raw",
         mlb=mlb,
         use_decision_function=True
     )

--- a/sklearn_hierarchical_classification/tests/fixtures.py
+++ b/sklearn_hierarchical_classification/tests/fixtures.py
@@ -141,9 +141,9 @@ def make_classifier_and_data(
     return clf, (X, y)
 
 
-def make_mlb_classifier_and_data_with_preprocessing():
+def make_mlb_classifier_and_data_with_feature_extraction_pipeline():
     """Create data set and classifier for testing a multi-label
-    classification scenario with a preprocessing pipeline.
+    classification scenario with a feature extraction pipeline.
 
     """
     newsgroups_train = fetch_20newsgroups(subset="train")

--- a/sklearn_hierarchical_classification/tests/fixtures.py
+++ b/sklearn_hierarchical_classification/tests/fixtures.py
@@ -142,6 +142,10 @@ def make_classifier_and_data(
 
 
 def make_classifier_and_data_own_preprocessing():
+    """Create data set and classifier for testing a multi-label
+    classification scenario with a preprocessing pipeline.
+
+    """
     newsgroups_train = fetch_20newsgroups(subset="train")
     X, Y = newsgroups_train.data, newsgroups_train.target
     class_hierarchy = make_newsgroups_hierarchy()
@@ -161,11 +165,11 @@ def make_classifier_and_data_own_preprocessing():
         max_features=70000
     )
     bclf = OneVsRestClassifier(LinearSVC())
-    base_estimator = make_pipeline(
-        vectorizer, bclf)
+    base_estimator = make_pipeline(vectorizer, bclf)
+
     labels = [
-        [names[tk]] + [names[tk].split(".")[0]]
-        for tk in Y
+        [names[target]] + [names[target].split(".")[0]]
+        for target in Y
     ]
     mlb = MultiLabelBinarizer()
     y = mlb.fit_transform(labels)
@@ -173,8 +177,6 @@ def make_classifier_and_data_own_preprocessing():
     clf = make_classifier(
         base_estimator=base_estimator,
         class_hierarchy=class_hierarchy,
-        algorithm="lcn",
-        training_strategy="siblings",
         preprocessing=True,
         mlb=mlb,
         use_decision_function=True

--- a/sklearn_hierarchical_classification/tests/fixtures.py
+++ b/sklearn_hierarchical_classification/tests/fixtures.py
@@ -92,6 +92,76 @@ def make_classifier_and_data(
         class_hierarchy=class_hierarchy,
         **classifier_kwargs
     )
+    
+    return clf, (X, y)
+
+
+def make_classifier_and_data_own_preprocessing():
+    from sklearn.datasets import fetch_20newsgroups
+    from sklearn.preprocessing import MultiLabelBinarizer
+    from sklearn.feature_extraction.text import TfidfVectorizer
+    from sklearn.svm import LinearSVC
+    from sklearn.multiclass import OneVsRestClassifier
+    from sklearn.pipeline import make_pipeline
+    
+    newsgroups_train = fetch_20newsgroups(subset='train')
+    X , Y= newsgroups_train.data, newsgroups_train.target
+
+    vectorizer = TfidfVectorizer(
+                strip_accents=None,
+                lowercase=True,
+                analyzer='word',
+                ngram_range=(1, 3),
+                max_df=1.0,
+                min_df=0.0,
+                binary=False,
+                use_idf=True,
+                smooth_idf=True,
+                sublinear_tf=True,
+                max_features=70000
+            )
+    hierarchy={}
+    hierarchy[ROOT]=["alt","comp","rec","misc","sci","soc","talk"]
+    hierarchy["alt"]=['alt.atheism']
+    hierarchy["comp"]= ['comp.graphics',
+                        'comp.os.ms-windows.misc',
+                        'comp.sys.ibm.pc.hardware',
+                        'comp.sys.mac.hardware',
+                        'comp.windows.x']
+    hierarchy["misc"]=[ 'misc.forsale']
+    hierarchy["rec"]=[ 'rec.autos',
+                      'rec.motorcycles',
+                      'rec.sport.baseball',
+                      'rec.sport.hockey']
+    hierarchy["sci"]= ['sci.crypt',
+                       'sci.electronics',
+                       'sci.med',
+                       'sci.space']
+    hierarchy["soc"]=[ 'soc.religion.christian']
+    hierarchy["talk"]=[ 'talk.politics.guns',
+                       'talk.politics.mideast',
+                       'talk.politics.misc',
+                       'talk.religion.misc']
+
+    class_hierarchy = hierarchy
+    
+    names = newsgroups_train.target_names
+    bclf = OneVsRestClassifier(LinearSVC())
+    base_estimator = make_pipeline(
+        vectorizer, bclf)
+    labels = [ [names[tk]]+[names[tk].split(".")[0]] for tk in Y]
+    mlb = MultiLabelBinarizer()
+    y=mlb.fit_transform(labels)
+    
+    clf = make_classifier(
+        base_estimator=base_estimator,
+        class_hierarchy=class_hierarchy,
+        algorithm="lcn",training_strategy= "siblings",
+        preprocessing=True,
+        mlb=mlb,
+        use_decision_function=True
+    )
+
 
     return clf, (X, y)
 

--- a/sklearn_hierarchical_classification/tests/test_classifier.py
+++ b/sklearn_hierarchical_classification/tests/test_classifier.py
@@ -28,6 +28,7 @@ from sklearn_hierarchical_classification.tests.fixtures import (
     make_classifier_and_data,
     make_clothing_graph_and_data,
     make_digits_dataset,
+    make_classifier_and_data_own_preprocessing
 )
 from sklearn_hierarchical_classification.tests.matchers import matches_graph
 
@@ -78,6 +79,29 @@ def test_trivial_hierarchy_classification():
     accuracy = accuracy_score(y_test, y_pred)
 
     assert_that(accuracy, is_(close_to(1., delta=0.05)))
+
+
+def test_trivial_hierarchy_classification_own_preprocessing_integration():
+    """Test that an integration with 20news groups and own preprocessing"""
+    print("integration test with 20news")
+    clf, (X, y) = make_classifier_and_data_own_preprocessing()
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X,
+        y,
+        test_size=0.30,
+        random_state=RANDOM_STATE,
+    )
+
+    clf.fit(X_train, y_train)
+    y_pred = clf.predict_proba(X_test)
+    import numpy as np
+    y_pred[np.where(y_pred==0)]=-1
+    accuracy = accuracy_score(y_test, y_pred>-0.2)
+    print("accuracy",accuracy)
+
+    assert_that(accuracy, is_(close_to(.8, delta=0.05)))
+    print("finished integration test")
 
 
 def test_base_estimator_as_dict():
@@ -304,3 +328,4 @@ def test_nmlnp_strategy_on_dag_with_dummy_classifier():
     y_pred = clf.predict(X_test)
 
     assert_that(list(y_pred), has_item("3a"))
+

--- a/sklearn_hierarchical_classification/tests/test_classifier.py
+++ b/sklearn_hierarchical_classification/tests/test_classifier.py
@@ -83,7 +83,6 @@ def test_trivial_hierarchy_classification():
 
 def test_trivial_hierarchy_classification_own_preprocessing_integration():
     """Test that an integration with 20news groups and own preprocessing"""
-    print("integration test with 20news")
     clf, (X, y) = make_classifier_and_data_own_preprocessing()
 
     X_train, X_test, y_train, y_test = train_test_split(

--- a/sklearn_hierarchical_classification/tests/test_classifier.py
+++ b/sklearn_hierarchical_classification/tests/test_classifier.py
@@ -24,11 +24,11 @@ from sklearn.utils.estimator_checks import check_estimator
 from sklearn_hierarchical_classification.classifier import HierarchicalClassifier
 from sklearn_hierarchical_classification.constants import CLASSIFIER, DEFAULT, ROOT
 from sklearn_hierarchical_classification.tests.fixtures import (
-    make_classifier,
     make_classifier_and_data,
-    make_classifier_and_data_own_preprocessing,
+    make_classifier,
     make_clothing_graph_and_data,
     make_digits_dataset,
+    make_mlb_classifier_and_data_with_preprocessing,
 )
 from sklearn_hierarchical_classification.tests.matchers import matches_graph
 
@@ -81,9 +81,9 @@ def test_trivial_hierarchy_classification():
     assert_that(accuracy, is_(close_to(1., delta=0.05)))
 
 
-def test_trivial_hierarchy_classification_own_preprocessing_integration():
-    """Test that an integration with 20news groups and own preprocessing"""
-    clf, (X, y) = make_classifier_and_data_own_preprocessing()
+def test_mlb_hierarchy_classification_with_preprocessing():
+    """Test multi-label classification with pre-processing pipeline"""
+    clf, (X, y) = make_mlb_classifier_and_data_with_preprocessing()
 
     X_train, X_test, y_train, y_test = train_test_split(
         X,

--- a/sklearn_hierarchical_classification/tests/test_classifier.py
+++ b/sklearn_hierarchical_classification/tests/test_classifier.py
@@ -24,11 +24,11 @@ from sklearn.utils.estimator_checks import check_estimator
 from sklearn_hierarchical_classification.classifier import HierarchicalClassifier
 from sklearn_hierarchical_classification.constants import CLASSIFIER, DEFAULT, ROOT
 from sklearn_hierarchical_classification.tests.fixtures import (
-    make_classifier_and_data,
     make_classifier,
+    make_classifier_and_data,
     make_clothing_graph_and_data,
     make_digits_dataset,
-    make_mlb_classifier_and_data_with_preprocessing,
+    make_mlb_classifier_and_data_with_feature_extraction_pipeline,
 )
 from sklearn_hierarchical_classification.tests.matchers import matches_graph
 
@@ -81,9 +81,9 @@ def test_trivial_hierarchy_classification():
     assert_that(accuracy, is_(close_to(1., delta=0.05)))
 
 
-def test_mlb_hierarchy_classification_with_preprocessing():
-    """Test multi-label classification with pre-processing pipeline"""
-    clf, (X, y) = make_mlb_classifier_and_data_with_preprocessing()
+def test_mlb_hierarchy_classification_with_feature_extraction_pipeline():
+    """Test multi-label classification with a feature extraction pipeline"""
+    clf, (X, y) = make_mlb_classifier_and_data_with_feature_extraction_pipeline()
 
     X_train, X_test, y_train, y_test = train_test_split(
         X,

--- a/sklearn_hierarchical_classification/tests/test_classifier.py
+++ b/sklearn_hierarchical_classification/tests/test_classifier.py
@@ -26,9 +26,9 @@ from sklearn_hierarchical_classification.constants import CLASSIFIER, DEFAULT, R
 from sklearn_hierarchical_classification.tests.fixtures import (
     make_classifier,
     make_classifier_and_data,
+    make_classifier_and_data_own_preprocessing,
     make_clothing_graph_and_data,
     make_digits_dataset,
-    make_classifier_and_data_own_preprocessing
 )
 from sklearn_hierarchical_classification.tests.matchers import matches_graph
 
@@ -95,13 +95,10 @@ def test_trivial_hierarchy_classification_own_preprocessing_integration():
 
     clf.fit(X_train, y_train)
     y_pred = clf.predict_proba(X_test)
-    import numpy as np
-    y_pred[np.where(y_pred==0)]=-1
-    accuracy = accuracy_score(y_test, y_pred>-0.2)
-    print("accuracy",accuracy)
+    y_pred[where(y_pred == 0)] = -1
+    accuracy = accuracy_score(y_test, y_pred > -0.2)
 
     assert_that(accuracy, is_(close_to(.8, delta=0.05)))
-    print("finished integration test")
 
 
 def test_base_estimator_as_dict():
@@ -328,4 +325,3 @@ def test_nmlnp_strategy_on_dag_with_dummy_classifier():
     y_pred = clf.predict(X_test)
 
     assert_that(list(y_pred), has_item("3a"))
-

--- a/sklearn_hierarchical_classification/validation.py
+++ b/sklearn_hierarchical_classification/validation.py
@@ -1,6 +1,7 @@
 """Validation helpers."""
 from sklearn_hierarchical_classification.constants import (
     VALID_ALGORITHM,
+    VALID_FEATURE_EXTRACTION,
     VALID_PREDICTION_DEPTH,
     VALID_TRAINING_STRATEGY,
 )
@@ -59,6 +60,13 @@ class ParameterValidator(object):
         )):
             raise TypeError(
                 """'stopping_criteria' must be set to a float or a callable."""
+            )
+
+        if self.feature_extraction not in VALID_FEATURE_EXTRACTION:
+            raise TypeError(
+                "'feature_extraction' must be set to one of: {}.".format(
+                    ", ".join(VALID_FEATURE_EXTRACTION),
+                )
             )
 
 


### PR DESCRIPTION
This PR is a clone of PR #20 which I'm using to do some cleanup on that original PR which originated with a fork there.

The primary enhancements provided by this work are:

* Support for multi-label classification via incorporating of a MultiLabelBinarizer into the classifier, along with accompanying unit-test fixtures and test cases
* Support for passing in the "raw" training data (e.g. text) rather than a pre-computed feature matrix, so that each local classifier can run its own classifier pipeline (e.g. using scikit-learn Pipeline) which opens the door to more fine-grained feature engineering and feature selection per node in the hierarchy.
* Other misc. cleanup and improvements to go along with these

This will be released as `2.0.0` version to PyPI once unit-test coverage and examples are in and this is merged.